### PR TITLE
Make `Surface::present()` errors non-fatal.

### DIFF
--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -3500,10 +3500,6 @@ impl Drop for CoreSurface {
 
 impl dispatch::SurfaceOutputDetailInterface for CoreSurfaceOutputDetail {
     fn present(&self) {
-        let error = SurfaceError::Device(wgc::device::DeviceError::Lost);
-        self.context
-            .handle_error_nolabel(&self.error_sink, error, "Surface::present");
-
         match self.context.0.surface_present(self.surface_id) {
             Ok(_status) => (),
             Err(err) => {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -13,7 +13,10 @@ use std::{
     borrow::Cow::Borrowed, error::Error, fmt, future::ready, ops::Range, pin::Pin, ptr::NonNull,
     slice, sync::Arc,
 };
-use wgc::{command::bundle_ffi::*, error::ContextErrorSource, pipeline::CreateShaderModuleError};
+use wgc::{
+    command::bundle_ffi::*, error::ContextErrorSource, pipeline::CreateShaderModuleError,
+    present::SurfaceError,
+};
 use wgt::WasmNotSendSync;
 
 #[derive(Clone)]
@@ -589,6 +592,7 @@ pub struct CoreTlas {
 pub struct CoreSurfaceOutputDetail {
     context: ContextWgpuCore,
     surface_id: wgc::id::SurfaceId,
+    error_sink: ErrorSink,
 }
 
 type ErrorSink = Arc<Mutex<ErrorSinkRaw>>;
@@ -3443,9 +3447,16 @@ impl dispatch::SurfaceInterface for CoreSurface {
         crate::SurfaceStatus,
         dispatch::DispatchSurfaceOutputDetail,
     ) {
+        let error_sink = if let Some(error_sink) = self.error_sink.lock().as_ref() {
+            error_sink.clone()
+        } else {
+            Arc::new(Mutex::new(ErrorSinkRaw::new()))
+        };
+
         let output_detail = CoreSurfaceOutputDetail {
             context: self.context.clone(),
             surface_id: self.id,
+            error_sink: error_sink.clone(),
         }
         .into();
 
@@ -3455,7 +3466,7 @@ impl dispatch::SurfaceInterface for CoreSurface {
                     .map(|id| CoreTexture {
                         context: self.context.clone(),
                         id,
-                        error_sink: Arc::new(Mutex::new(ErrorSinkRaw::new())),
+                        error_sink,
                     })
                     .map(Into::into);
 
@@ -3489,9 +3500,16 @@ impl Drop for CoreSurface {
 
 impl dispatch::SurfaceOutputDetailInterface for CoreSurfaceOutputDetail {
     fn present(&self) {
+        let error = SurfaceError::Device(wgc::device::DeviceError::Lost);
+        self.context
+            .handle_error_nolabel(&self.error_sink, error, "Surface::present");
+
         match self.context.0.surface_present(self.surface_id) {
             Ok(_status) => (),
-            Err(err) => self.context.handle_error_fatal(err, "Surface::present"),
+            Err(err) => {
+                self.context
+                    .handle_error_nolabel(&self.error_sink, err, "Surface::present");
+            }
         }
     }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -13,10 +13,7 @@ use std::{
     borrow::Cow::Borrowed, error::Error, fmt, future::ready, ops::Range, pin::Pin, ptr::NonNull,
     slice, sync::Arc,
 };
-use wgc::{
-    command::bundle_ffi::*, error::ContextErrorSource, pipeline::CreateShaderModuleError,
-    present::SurfaceError,
-};
+use wgc::{command::bundle_ffi::*, error::ContextErrorSource, pipeline::CreateShaderModuleError};
 use wgt::WasmNotSendSync;
 
 #[derive(Clone)]


### PR DESCRIPTION
## Description

WISOTT.

We need this in order to be able to catch device loss errors using an error scope and handle them gracefully.

## Testing

- [x] Tested by adding the following code at the start of `present()` that unconditionally produces a `DeviceError::Lost` and verified that Warp will detect it and try to recreate the renderer.

```rust
let error = SurfaceError::Device(wgc::device::DeviceError::Lost);
self.context
    .handle_error_nolabel(&self.error_sink, error, "Surface::present");
```