### PR TITLE
[backport] fix(dx12): map composite alpha mode (#7117)

### DIFF
--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -281,6 +281,13 @@ pub fn map_vertex_format(format: wgt::VertexFormat) -> Dxgi::Common::DXGI_FORMAT
     }
 }
 
-pub fn map_acomposite_alpha_mode(_mode: wgt::CompositeAlphaMode) -> Dxgi::Common::DXGI_ALPHA_MODE {
-    Dxgi::Common::DXGI_ALPHA_MODE_IGNORE
+pub fn map_acomposite_alpha_mode(mode: wgt::CompositeAlphaMode) -> Dxgi::Common::DXGI_ALPHA_MODE {
+    match mode {
+        wgt::CompositeAlphaMode::PreMultiplied => Dxgi::Common::DXGI_ALPHA_MODE_PREMULTIPLIED,
+        wgt::CompositeAlphaMode::PostMultiplied => Dxgi::Common::DXGI_ALPHA_MODE_STRAIGHT,
+        wgt::CompositeAlphaMode::Opaque => Dxgi::Common::DXGI_ALPHA_MODE_IGNORE,
+        wgt::CompositeAlphaMode::Auto | wgt::CompositeAlphaMode::Inherit => {
+            Dxgi::Common::DXGI_ALPHA_MODE_UNSPECIFIED
+        }
+    }
 }

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -828,7 +828,18 @@ impl crate::Adapter for super::Adapter {
                 | crate::TextureUses::COPY_SRC
                 | crate::TextureUses::COPY_DST,
             present_modes,
-            composite_alpha_modes: vec![wgt::CompositeAlphaMode::Opaque],
+            composite_alpha_modes: match surface.target {
+                SurfaceTarget::WndHandle(_) => vec![wgt::CompositeAlphaMode::Opaque],
+                SurfaceTarget::Visual(_)
+                | SurfaceTarget::SurfaceHandle(_)
+                | SurfaceTarget::SwapChainPanel(_) => vec![
+                    wgt::CompositeAlphaMode::Auto,
+                    wgt::CompositeAlphaMode::Inherit,
+                    wgt::CompositeAlphaMode::Opaque,
+                    wgt::CompositeAlphaMode::PostMultiplied,
+                    wgt::CompositeAlphaMode::PreMultiplied,
+                ],
+            },
         })
     }
 


### PR DESCRIPTION
Cherrypick of https://github.com/gfx-rs/wgpu/pull/7117 into our v24 branch, which ensures that we'll actually advertise appropriate alpha mode support for DirectComposition-based surfaces.