### PR TITLE
Add support for using DirectComposition with DirectX 12.

### DIFF
--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -394,6 +394,7 @@ pub fn op_webgpu_request_adapter(
                 backend_options: wgpu_types::BackendOptions {
                     dx12: wgpu_types::Dx12BackendOptions {
                         shader_compiler: wgpu_types::Dx12Compiler::Fxc,
+                        use_dcomp: false,
                     },
                     gl: wgpu_types::GlBackendOptions {
                         gles_minor_version: wgpu_types::Gles3MinorVersion::default(),

--- a/examples/src/framework.rs
+++ b/examples/src/framework.rs
@@ -551,7 +551,7 @@ impl<E: Example + wgpu::WasmNotSendSync> From<ExampleTestParams<E>>
                         height: params.height,
                         desired_maximum_frame_latency: 2,
                         present_mode: wgpu::PresentMode::Fifo,
-                        alpha_mode: wgpu::CompositeAlphaMode::Opaque,
+                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![format],
                     },
                     &ctx.adapter,

--- a/examples/src/framework.rs
+++ b/examples/src/framework.rs
@@ -551,7 +551,7 @@ impl<E: Example + wgpu::WasmNotSendSync> From<ExampleTestParams<E>>
                         height: params.height,
                         desired_maximum_frame_latency: 2,
                         present_mode: wgpu::PresentMode::Fifo,
-                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                        alpha_mode: wgpu::CompositeAlphaMode::Opaque,
                         view_formats: vec![format],
                     },
                     &ctx.adapter,

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -43,6 +43,7 @@ pub fn initialize_instance(backends: wgpu::Backends, force_fxc: bool) -> Instanc
         backend_options: wgpu::BackendOptions {
             dx12: wgpu::Dx12BackendOptions {
                 shader_compiler: dx12_shader_compiler,
+                use_dcomp: false,
             },
             gl: wgpu::GlBackendOptions { gles_minor_version },
         },

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -78,6 +78,7 @@ impl Instance {
                         .dx12
                         .shader_compiler
                         .clone(),
+                    dx12_use_dcomp: instance_desc.backend_options.dx12.use_dcomp,
                     gles_minor_version: instance_desc.backend_options.gl.gles_minor_version,
                 };
 

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -82,6 +82,8 @@ dx12 = [
     "windows/Win32_Graphics_Direct3D_Fxc",
     "windows/Win32_Graphics_Direct3D_Dxc",
     "windows/Win32_Graphics_Direct3D",
+    "windows/Win32_Graphics_Direct3D11",
+    "windows/Win32_Graphics_Direct3D11on12",
     "windows/Win32_Graphics_Direct3D12",
     "windows/Win32_Graphics_DirectComposition",
     "windows/Win32_Graphics_Dxgi_Common",

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -98,6 +98,7 @@ impl<A: hal::Api> Example<A> {
             flags: wgt::InstanceFlags::from_build_config().with_env(),
             // Can't rely on having DXC available, so use FXC instead
             dx12_shader_compiler: wgt::Dx12Compiler::Fxc,
+            dx12_use_dcomp: false,
             gles_minor_version: wgt::Gles3MinorVersion::default(),
         };
         let instance = unsafe { A::Instance::init(&instance_desc)? };

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -243,6 +243,7 @@ impl<A: hal::Api> Example<A> {
                 dxc_path: "dxcompiler.dll".to_string(),
                 dxil_path: "dxil.dll".to_string(),
             },
+            dx12_use_dcomp: false,
             gles_minor_version: wgt::Gles3MinorVersion::default(),
         };
         let instance = unsafe { A::Instance::init(&instance_desc)? };

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -787,7 +787,10 @@ impl crate::Adapter for super::Adapter {
     ) -> Option<crate::SurfaceCapabilities> {
         let current_extent = {
             match surface.target {
-                SurfaceTarget::WndHandle(wnd_handle) => {
+                SurfaceTarget::WndHandle(wnd_handle)
+                | SurfaceTarget::VisualFromWndHandle {
+                    handle: wnd_handle, ..
+                } => {
                     let mut rect = Default::default();
                     if unsafe { WindowsAndMessaging::GetClientRect(wnd_handle, &mut rect) }.is_ok()
                     {
@@ -831,6 +834,7 @@ impl crate::Adapter for super::Adapter {
             composite_alpha_modes: match surface.target {
                 SurfaceTarget::WndHandle(_) => vec![wgt::CompositeAlphaMode::Opaque],
                 SurfaceTarget::Visual(_)
+                | SurfaceTarget::VisualFromWndHandle { .. }
                 | SurfaceTarget::SurfaceHandle(_)
                 | SurfaceTarget::SwapChainPanel(_) => vec![
                     wgt::CompositeAlphaMode::Auto,

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -108,6 +108,7 @@ impl crate::Instance for super::Instance {
             library: Arc::new(lib_main),
             _lib_dxgi: lib_dxgi,
             supports_allow_tearing,
+            use_dcomp: desc.dx12_use_dcomp,
             flags: desc.flags,
             dxc_container,
         })
@@ -119,14 +120,26 @@ impl crate::Instance for super::Instance {
         window_handle: raw_window_handle::RawWindowHandle,
     ) -> Result<super::Surface, crate::InstanceError> {
         match window_handle {
-            raw_window_handle::RawWindowHandle::Win32(handle) => Ok(super::Surface {
-                factory: self.factory.clone(),
-                factory_media: self.factory_media.clone(),
+            raw_window_handle::RawWindowHandle::Win32(handle) => {
                 // https://github.com/rust-windowing/raw-window-handle/issues/171
-                target: SurfaceTarget::WndHandle(Foundation::HWND(handle.hwnd.get() as *mut _)),
-                supports_allow_tearing: self.supports_allow_tearing,
-                swap_chain: RwLock::new(None),
-            }),
+                let handle = Foundation::HWND(handle.hwnd.get() as *mut _);
+                let target = if self.use_dcomp {
+                    SurfaceTarget::VisualFromWndHandle {
+                        handle,
+                        dcomp_state: Default::default(),
+                    }
+                } else {
+                    SurfaceTarget::WndHandle(handle)
+                };
+                Ok(super::Surface {
+                    factory: self.factory.clone(),
+                    factory_media: self.factory_media.clone(),
+
+                    target,
+                    supports_allow_tearing: self.supports_allow_tearing,
+                    swap_chain: RwLock::new(None),
+                })
+            }
             _ => Err(crate::InstanceError::new(format!(
                 "window handle {window_handle:?} is not a Win32 handle"
             ))),

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -1261,6 +1261,9 @@ impl crate::Surface for Surface {
                             dcomp_state.visual.SetContent(&swap_chain1).map_err(|_| {
                                 crate::SurfaceError::Other("IDCompositionVisual::SetContent")
                             })?;
+                            dcomp_state.device.Commit().map_err(|_| {
+                                crate::SurfaceError::Other("IDCompositionDevice::Commit")
+                            })?;
                         }
                     }
                     SurfaceTarget::Visual(visual) => {
@@ -1435,29 +1438,6 @@ impl crate::Queue for Queue {
         }
         .ok()
         .into_device_result("Present")?;
-
-        if let SurfaceTarget::VisualFromWndHandle { dcomp_state, .. } = &surface.target {
-            let dcomp_state = dcomp_state.read();
-            let dcomp_state = dcomp_state.as_ref().unwrap();
-            unsafe {
-                if dcomp_state
-                    .device
-                    .CheckDeviceState()
-                    .map_err(|_| {
-                        crate::SurfaceError::Other("IDCompositionDevice::CheckDeviceState")
-                    })?
-                    .into()
-                {
-                    profiling::scope!("IDCompositionDevice::Commit");
-                    dcomp_state
-                        .device
-                        .Commit()
-                        .map_err(|_| crate::SurfaceError::Other("IDCompositionDevice::Commit"))?;
-                } else {
-                    return Err(crate::SurfaceError::Lost);
-                }
-            }
-        }
 
         Ok(())
     }

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -52,7 +52,7 @@ use windows::{
     core::{Free, Interface},
     Win32::{
         Foundation,
-        Graphics::{Direct3D, Direct3D12, DirectComposition, Dxgi},
+        Graphics::{Direct3D, Direct3D11, Direct3D11on12, Direct3D12, DirectComposition, Dxgi},
         System::Threading,
     },
 };
@@ -410,6 +410,7 @@ pub struct Instance {
     factory_media: Option<Dxgi::IDXGIFactoryMedia>,
     library: Arc<D3D12Lib>,
     supports_allow_tearing: bool,
+    use_dcomp: bool,
     _lib_dxgi: DxgiLib,
     flags: wgt::InstanceFlags,
     dxc_container: Option<Arc<shader_compilation::DxcContainer>>,
@@ -479,9 +480,21 @@ struct SwapChain {
     size: wgt::Extent3d,
 }
 
+struct DCompState {
+    visual: DirectComposition::IDCompositionVisual,
+    device: DirectComposition::IDCompositionDevice,
+    // Must be kept alive but is otherwise unused after initialization.
+    _target: DirectComposition::IDCompositionTarget,
+}
+
 enum SurfaceTarget {
     /// Borrowed, lifetime externally managed
     WndHandle(Foundation::HWND),
+    /// `handle` is borrowed, lifetime externally managed
+    VisualFromWndHandle {
+        handle: Foundation::HWND,
+        dcomp_state: RwLock<Option<DCompState>>,
+    },
     Visual(DirectComposition::IDCompositionVisual),
     /// Borrowed, lifetime externally managed
     SurfaceHandle(Foundation::HANDLE),
@@ -1147,6 +1160,61 @@ impl crate::Surface for Surface {
                             )
                         }
                     }
+                    SurfaceTarget::VisualFromWndHandle {
+                        handle,
+                        ref dcomp_state,
+                    } => unsafe {
+                        macro_rules! call {
+                            ($name:literal, $e:expr) => {{
+                                profiling::scope!($name);
+                                ($e).map_err(|_| crate::SurfaceError::Other($name))?
+                            }};
+                        }
+
+                        let mut d3d11_device = None;
+                        call!(
+                            "Direct3D11on12::D3D11On12CreateDevice",
+                            Direct3D11on12::D3D11On12CreateDevice(
+                                &device.raw,
+                                Direct3D11::D3D11_CREATE_DEVICE_BGRA_SUPPORT.0,
+                                None,
+                                None,
+                                0,
+                                Some(&mut d3d11_device),
+                                None,
+                                None,
+                            )
+                        );
+                        let d3d11_device = d3d11_device.unwrap();
+                        let dxgi_device: Dxgi::IDXGIDevice =
+                            call!("IDXGIDevice::QueryInterface", d3d11_device.cast());
+                        let dcomp_device: DirectComposition::IDCompositionDevice = call!(
+                            "DirectComposition::DCompositionCreateDevice",
+                            DirectComposition::DCompositionCreateDevice(&dxgi_device)
+                        );
+                        let target = call!(
+                            "IDCompositionDevice::CreateTargetForHwnd",
+                            dcomp_device.CreateTargetForHwnd(handle, false)
+                        );
+                        let visual = call!(
+                            "IDCompositionDevice::CreateVisual",
+                            dcomp_device.CreateVisual()
+                        );
+                        call!("IDCompositionTarget::SetRoot", target.SetRoot(&visual));
+
+                        *dcomp_state.write() = Some(DCompState {
+                            visual,
+                            device: dcomp_device,
+                            _target: target,
+                        });
+
+                        profiling::scope!("IDXGIFactory2::CreateSwapChainForComposition");
+                        self.factory.CreateSwapChainForComposition(
+                            &device.present_queue,
+                            &desc,
+                            None,
+                        )
+                    },
                     SurfaceTarget::SurfaceHandle(handle) => {
                         profiling::scope!(
                             "IDXGIFactoryMedia::CreateSwapChainForCompositionSurfaceHandle"
@@ -1184,6 +1252,17 @@ impl crate::Surface for Surface {
 
                 match &self.target {
                     SurfaceTarget::WndHandle(_) | SurfaceTarget::SurfaceHandle(_) => {}
+                    SurfaceTarget::VisualFromWndHandle { dcomp_state, .. } => {
+                        let dcomp_state = dcomp_state.read();
+                        let dcomp_state = dcomp_state
+                            .as_ref()
+                            .expect("dcomp_state was initialized above");
+                        unsafe {
+                            dcomp_state.visual.SetContent(&swap_chain1).map_err(|_| {
+                                crate::SurfaceError::Other("IDCompositionVisual::SetContent")
+                            })?;
+                        }
+                    }
                     SurfaceTarget::Visual(visual) => {
                         if let Err(err) = unsafe { visual.SetContent(&swap_chain1) } {
                             log::error!("Unable to SetContent: {err}");
@@ -1221,6 +1300,7 @@ impl crate::Surface for Surface {
                 .into_device_result("MakeWindowAssociation")?;
             }
             SurfaceTarget::Visual(_)
+            | SurfaceTarget::VisualFromWndHandle { .. }
             | SurfaceTarget::SurfaceHandle(_)
             | SurfaceTarget::SwapChainPanel(_) => {}
         }
@@ -1349,10 +1429,35 @@ impl crate::Queue for Queue {
             m => unreachable!("Cannot make surface with present mode {m:?}"),
         };
 
-        profiling::scope!("IDXGISwapchain3::Present");
-        unsafe { sc.raw.Present(interval, flags) }
-            .ok()
-            .into_device_result("Present")?;
+        unsafe {
+            profiling::scope!("IDXGISwapchain3::Present");
+            sc.raw.Present(interval, flags)
+        }
+        .ok()
+        .into_device_result("Present")?;
+
+        if let SurfaceTarget::VisualFromWndHandle { dcomp_state, .. } = &surface.target {
+            let dcomp_state = dcomp_state.read();
+            let dcomp_state = dcomp_state.as_ref().unwrap();
+            unsafe {
+                if dcomp_state
+                    .device
+                    .CheckDeviceState()
+                    .map_err(|_| {
+                        crate::SurfaceError::Other("IDCompositionDevice::CheckDeviceState")
+                    })?
+                    .into()
+                {
+                    profiling::scope!("IDCompositionDevice::Commit");
+                    dcomp_state
+                        .device
+                        .Commit()
+                        .map_err(|_| crate::SurfaceError::Other("IDCompositionDevice::Commit"))?;
+                } else {
+                    return Err(crate::SurfaceError::Lost);
+                }
+            }
+        }
 
         Ok(())
     }

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -1432,12 +1432,10 @@ impl crate::Queue for Queue {
             m => unreachable!("Cannot make surface with present mode {m:?}"),
         };
 
-        unsafe {
-            profiling::scope!("IDXGISwapchain3::Present");
-            sc.raw.Present(interval, flags)
-        }
-        .ok()
-        .into_device_result("Present")?;
+        profiling::scope!("IDXGISwapchain3::Present");
+        unsafe { sc.raw.Present(interval, flags) }
+            .ok()
+            .into_device_result("Present")?;
 
         Ok(())
     }

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -1150,7 +1150,9 @@ impl crate::Surface for Surface {
                     Flags: flags.0 as u32,
                 };
                 let swap_chain1 = match self.target {
-                    SurfaceTarget::Visual(_) | SurfaceTarget::SwapChainPanel(_) => {
+                    SurfaceTarget::Visual(_)
+                    | SurfaceTarget::VisualFromWndHandle { .. }
+                    | SurfaceTarget::SwapChainPanel(_) => {
                         profiling::scope!("IDXGIFactory2::CreateSwapChainForComposition");
                         unsafe {
                             self.factory.CreateSwapChainForComposition(
@@ -1160,61 +1162,6 @@ impl crate::Surface for Surface {
                             )
                         }
                     }
-                    SurfaceTarget::VisualFromWndHandle {
-                        handle,
-                        ref dcomp_state,
-                    } => unsafe {
-                        macro_rules! call {
-                            ($name:literal, $e:expr) => {{
-                                profiling::scope!($name);
-                                ($e).map_err(|_| crate::SurfaceError::Other($name))?
-                            }};
-                        }
-
-                        let mut d3d11_device = None;
-                        call!(
-                            "Direct3D11on12::D3D11On12CreateDevice",
-                            Direct3D11on12::D3D11On12CreateDevice(
-                                &device.raw,
-                                Direct3D11::D3D11_CREATE_DEVICE_BGRA_SUPPORT.0,
-                                None,
-                                None,
-                                0,
-                                Some(&mut d3d11_device),
-                                None,
-                                None,
-                            )
-                        );
-                        let d3d11_device = d3d11_device.unwrap();
-                        let dxgi_device: Dxgi::IDXGIDevice =
-                            call!("IDXGIDevice::QueryInterface", d3d11_device.cast());
-                        let dcomp_device: DirectComposition::IDCompositionDevice = call!(
-                            "DirectComposition::DCompositionCreateDevice",
-                            DirectComposition::DCompositionCreateDevice(&dxgi_device)
-                        );
-                        let target = call!(
-                            "IDCompositionDevice::CreateTargetForHwnd",
-                            dcomp_device.CreateTargetForHwnd(handle, false)
-                        );
-                        let visual = call!(
-                            "IDCompositionDevice::CreateVisual",
-                            dcomp_device.CreateVisual()
-                        );
-                        call!("IDCompositionTarget::SetRoot", target.SetRoot(&visual));
-
-                        *dcomp_state.write() = Some(DCompState {
-                            visual,
-                            device: dcomp_device,
-                            _target: target,
-                        });
-
-                        profiling::scope!("IDXGIFactory2::CreateSwapChainForComposition");
-                        self.factory.CreateSwapChainForComposition(
-                            &device.present_queue,
-                            &desc,
-                            None,
-                        )
-                    },
                     SurfaceTarget::SurfaceHandle(handle) => {
                         profiling::scope!(
                             "IDXGIFactoryMedia::CreateSwapChainForCompositionSurfaceHandle"
@@ -1252,20 +1199,70 @@ impl crate::Surface for Surface {
 
                 match &self.target {
                     SurfaceTarget::WndHandle(_) | SurfaceTarget::SurfaceHandle(_) => {}
-                    SurfaceTarget::VisualFromWndHandle { dcomp_state, .. } => {
-                        let dcomp_state = dcomp_state.read();
-                        let dcomp_state = dcomp_state
-                            .as_ref()
-                            .expect("dcomp_state was initialized above");
-                        unsafe {
-                            dcomp_state.visual.SetContent(&swap_chain1).map_err(|_| {
-                                crate::SurfaceError::Other("IDCompositionVisual::SetContent")
-                            })?;
-                            dcomp_state.device.Commit().map_err(|_| {
-                                crate::SurfaceError::Other("IDCompositionDevice::Commit")
-                            })?;
+                    SurfaceTarget::VisualFromWndHandle {
+                        handle,
+                        dcomp_state,
+                    } => unsafe {
+                        macro_rules! call {
+                            ($name:literal, $e:expr) => {{
+                                profiling::scope!($name);
+                                ($e).map_err(|_| crate::SurfaceError::Other($name))?
+                            }};
                         }
-                    }
+
+                        // Initialize the window-linked DirectComposition state
+                        // if we haven't done so already.
+                        let mut dcomp_state = dcomp_state.write();
+                        let dcomp_state = match dcomp_state.as_mut() {
+                            Some(s) => s,
+                            None => {
+                                let mut d3d11_device = None;
+                                call!(
+                                    "Direct3D11on12::D3D11On12CreateDevice",
+                                    Direct3D11on12::D3D11On12CreateDevice(
+                                        &device.raw,
+                                        Direct3D11::D3D11_CREATE_DEVICE_BGRA_SUPPORT.0,
+                                        None,
+                                        None,
+                                        0,
+                                        Some(&mut d3d11_device),
+                                        None,
+                                        None,
+                                    )
+                                );
+                                let d3d11_device = d3d11_device.unwrap();
+                                let dxgi_device: Dxgi::IDXGIDevice =
+                                    call!("IDXGIDevice::QueryInterface", d3d11_device.cast());
+                                let dcomp_device: DirectComposition::IDCompositionDevice = call!(
+                                    "DirectComposition::DCompositionCreateDevice",
+                                    DirectComposition::DCompositionCreateDevice(&dxgi_device)
+                                );
+                                let target = call!(
+                                    "IDCompositionDevice::CreateTargetForHwnd",
+                                    dcomp_device.CreateTargetForHwnd(*handle, false)
+                                );
+                                let visual = call!(
+                                    "IDCompositionDevice::CreateVisual",
+                                    dcomp_device.CreateVisual()
+                                );
+                                call!("IDCompositionTarget::SetRoot", target.SetRoot(&visual));
+
+                                dcomp_state.insert(DCompState {
+                                    visual,
+                                    device: dcomp_device,
+                                    _target: target,
+                                })
+                            }
+                        };
+
+                        // Set the new swap chain as the content for the backing visual
+                        // and commit the changes to the composition visual tree.
+                        call!(
+                            "IDCompositionVisual::SetContent",
+                            dcomp_state.visual.SetContent(&swap_chain1)
+                        );
+                        call!("IDCompositionDevice::Commit", dcomp_state.device.Commit());
+                    },
                     SurfaceTarget::Visual(visual) => {
                         if let Err(err) = unsafe { visual.SetContent(&swap_chain1) } {
                             log::error!("Unable to SetContent: {err}");

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -1752,6 +1752,7 @@ pub struct InstanceDescriptor<'a> {
     pub name: &'a str,
     pub flags: wgt::InstanceFlags,
     pub dx12_shader_compiler: wgt::Dx12Compiler,
+    pub dx12_use_dcomp: bool,
     pub gles_minor_version: wgt::Gles3MinorVersion,
 }
 

--- a/wgpu-types/src/instance.rs
+++ b/wgpu-types/src/instance.rs
@@ -243,6 +243,8 @@ impl GlBackendOptions {
 pub struct Dx12BackendOptions {
     /// Which DX12 shader compiler to use.
     pub shader_compiler: Dx12Compiler,
+    /// Whether to use DirectComposition for managing presentation.
+    pub use_dcomp: bool,
 }
 
 impl Dx12BackendOptions {
@@ -254,6 +256,7 @@ impl Dx12BackendOptions {
         let compiler = Dx12Compiler::from_env().unwrap_or_default();
         Self {
             shader_compiler: compiler,
+            use_dcomp: false,
         }
     }
 
@@ -263,7 +266,10 @@ impl Dx12BackendOptions {
     #[must_use]
     pub fn with_env(self) -> Self {
         let shader_compiler = self.shader_compiler.with_env();
-        Self { shader_compiler }
+        Self {
+            shader_compiler,
+            use_dcomp: false,
+        }
     }
 }
 


### PR DESCRIPTION
This adds support for opting-in to using DirectComposition to manage interaction between a DXGI swapchain and a window, allowing for proper transparency support when using DirectX 12.

I tested this manually on my machine, by pointing a local build of Warp at my local copy of wgpu and setting the `use_dcomp` DX12 backend flag to `true`.

Controlling this via backend flag means we could have it be behind an experiment flag for a week or only enabled when window opacity is <100 or whatever we want to do to de-risk.